### PR TITLE
Support for Time on Kronic.format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 .bundle
+.DS_Store

--- a/lib/kronic.rb
+++ b/lib/kronic.rb
@@ -32,7 +32,7 @@ class Kronic
   # Returns a relative string ("Today", "This Monday") if available, otherwise
   # the full representation of the date ("19 September 2010").
   def self.format(date, opts = {})
-    case (date - (opts[:today] || today)).to_i
+    case (date.to_date - (opts[:today] || today)).to_i
       when (2..7)   then "This " + date.strftime("%A")
       when 1        then "Tomorrow"
       when 0        then "Today"

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -62,6 +62,8 @@ describe Kronic do
   should_format('Last Monday', date(:last_monday))
   should_format('This Monday', date(:next_monday))
   should_format('14 September 2008', Date.new(2008, 9, 14))
+  
+  should_format('Today',        Time.utc(2010,"sep",18))
 
   describe 'timezone support' do
     before :all do


### PR DESCRIPTION
Hi Xavier,

I added a .to_date call in Kronic.format to force the date parameter to a Date. 

Another library I was using was returning Time instead of Date. This was causing an exception to be raised about converting a Date to a float. I could call .to_date before Kronic, but I figured I would not be the only person to run into this.

I am still a little new with Ruby, so if this is a dumb thing to do, please feel free to ignore me (although I would love to hear if it is in fact dumb :).

Thanks,
Scott
