### PR TITLE
Format as an optional parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 .bundle
+.DS_Store

--- a/lib/kronic.rb
+++ b/lib/kronic.rb
@@ -32,7 +32,7 @@ class Kronic
   # Returns a relative string ("Today", "This Monday") if available, otherwise
   # the full representation of the date ("19 September 2010").
   def self.format(date, opts = {})
-    case (date - (opts[:today] || today)).to_i
+    case (date.to_date - (opts[:today] || today)).to_i
       when (2..7)   then "This " + date.strftime("%A")
       when 1        then "Tomorrow"
       when 0        then "Today"

--- a/lib/kronic.rb
+++ b/lib/kronic.rb
@@ -28,6 +28,7 @@ class Kronic
   # date - The Date to be converted
   # opts - The Hash options used to customize formatting
   #        :today - The reference point for calculations (default: Date.today)
+  #        :format - A strftime override (default: "%e %B %Y")
   #
   # Returns a relative string ("Today", "This Monday") if available, otherwise
   # the full representation of the date ("19 September 2010").
@@ -38,7 +39,7 @@ class Kronic
       when 0        then "Today"
       when -1       then "Yesterday"
       when (-7..-2) then "Last " + date.strftime("%A")
-      else              date.strftime("%e %B %Y").strip
+      else              date.strftime(opts[:format] || "%e %B %Y").strip
     end
   end
 

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -7,9 +7,9 @@ describe Kronic do
     end
   end
 
-  def self.should_format(string, date)
+  def self.should_format(string, date, opts = {})
     it "should format '#{string}'" do
-      Kronic.format(date).should == string
+      Kronic.format(date,opts).should == string
     end
   end
 
@@ -62,8 +62,10 @@ describe Kronic do
   should_format('Last Monday', date(:last_monday))
   should_format('This Monday', date(:next_monday))
   should_format('14 September 2008', Date.new(2008, 9, 14))
-  
+  should_format('September 14, 2008', Date.new(2008, 9, 14), :format => "%B %e, %Y")  
   should_format('Today',        Time.utc(2010,"sep",18))
+
+
 
   describe 'timezone support' do
     before :all do

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -62,6 +62,8 @@ describe Kronic do
   should_format('Last Monday', date(:last_monday))
   should_format('This Monday', date(:next_monday))
   should_format('14 September 2008', Date.new(2008, 9, 14))
+  
+  should_format('Today',        Time.utc(2010,"sep",18))
 
   describe 'timezone support' do
     before :all do


### PR DESCRIPTION
Hi Xavier,

I added :format as an option on Kronic.format which allows you to override the default date format. 

Thanks,
Scott
