### PR TITLE
It'd be cool if Kronic.parse didn't depend on strftime

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kronic (0.4.1)
+    kronic (1.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/js/kronic.js
+++ b/lib/js/kronic.js
@@ -7,15 +7,8 @@ var Kronic = (function() {
   var NUMBER_WITH_ORDINAL = /^([0-9]+)(st|nd|rd|th)?$/;
   var ISO_8601_DATE       = /^([0-9]{4})-?(1[0-2]|0?[1-9])-?(3[0-1]|[1-2][0-9]|0?[1-9])$/;
 
-  var MONTH_NAMES = [];
-
-  for (var i = 0; i < 12; i++) {
-    var addMonth = function(formatter) {
-      MONTH_NAMES.push((new Date(2010, i, 1)).strftime(formatter).toLowerCase());
-    };
-    addMonth("%b");
-    addMonth("%B");
-  }
+  var MONTH_NAMES = ["january", "jan", "february", "feb", "march", "mar", "april", "apr", "may", "may", "june", "jun", "july", "jul", "august", "aug", "september", "sep", "october", "oct", "november", "nov", "december", "dec"];
+  var DAY_NAMES = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
 
   function trim(string) {
     return string.replace(/^\s+|\s+$/g, '');
@@ -56,7 +49,7 @@ var Kronic = (function() {
       });
 
       days = inject(days, {}, function(a, x) {
-        a[x.strftime("%A").toLowerCase()] = x;
+        a[DAY_NAMES[x.getDay()]] = x;
         return a;
       });
 


### PR DESCRIPTION
This way it could be used separately if one only needs to parse dates.
