### PR TITLE
A couple of bugs in JS version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kronic (1.0.0)
+    kronic (1.1.0)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/js/kronic.js
+++ b/lib/js/kronic.js
@@ -92,6 +92,12 @@ var Kronic = (function() {
       return null;
 
     var result = new Date(year, month, day);
+
+    // Date constructor will hapilly accept invalid dates
+    // so we're checking that day existed in the given month
+    if (result.getMonth() != month)
+      return null;
+
     if (result > today && !rawYear)
       result = new Date(year - 1, month, day);
     return result;

--- a/lib/js/kronic.js
+++ b/lib/js/kronic.js
@@ -88,7 +88,7 @@ var Kronic = (function() {
     else
       year = today.getYear() + 1900;
 
-    if (!(day && month && year))
+    if (!(day && month != null && year))
       return null;
 
     var result = new Date(year, month, day);

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -66,6 +66,7 @@ describe Kronic do
   it_should_parse('September 4',        date(:sep_4))
   it_should_parse('2008-09-04',         Date.new(2008, 9, 4))
   it_should_parse('2008-9-4',           Date.new(2008, 9, 4))
+  it_should_parse('1 Jan 2010',         Date.new(2010, 1, 1))
   it_should_parse('bogus',              nil)
   it_should_parse('14',                 nil)
   it_should_parse('14 bogus in',        nil)


### PR DESCRIPTION
JS version can't parse dates in January, as the month's index in the names array is 0 and it's falsy in JS (this might sound confusing, but just check the commit)

Also, JS Date constructor accepts any numbers for month and day at least, so new Date(2010, 1, 1999) where 1999 is day willl work perfectly fine: it'll add 1999 days to the 1 Jan 2010 and return a date in 2012. In ruby Date.new just throws an exception in such case. So I've added a simple check for the resulting date in JS. If this is confusing just apply the first commit and run tests.

Thanks.
