### PR TITLE
Adding support for "next xxx", abbreviated day names and exact day names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :rubygems
 
 platforms(:mri) do # This should exclude rbx, but doesn't in my testing
-  gem 'therubyracer', '>= 0.8.0.pre2' unless RUBY_ENGINE == 'rbx'
+  gem 'therubyracer', '>= 0.8.0.pre2' unless defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
 end
 
 gemspec

--- a/lib/js/kronic.js
+++ b/lib/js/kronic.js
@@ -9,7 +9,8 @@ var Kronic = (function() {
 
   var MONTH_NAMES = ["january", "jan", "february", "feb", "march", "mar", "april", "apr", "may", "may", "june", "jun", "july", "jul", "august", "aug", "september", "sep", "october", "oct", "november", "nov", "december", "dec"];
   var DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-
+  var ABBR_DAY_NAMES = ["Sun", "Mon", "Tues", "Weds", "Thurs", "Fri", "Sat"];
+  
   function trim(string) {
     return string.replace(/^\s+|\s+$/g, '');
   }
@@ -54,6 +55,7 @@ var Kronic = (function() {
 
       days = inject(days, {}, function(a, x) {
         a[DAY_NAMES[x.getDay()].toLowerCase()] = x;
+        a[ABBR_DAY_NAMES[x.getDay()].toLowerCase()] = x;
         return a;
       });
 

--- a/lib/js/kronic.js
+++ b/lib/js/kronic.js
@@ -45,21 +45,26 @@ var Kronic = (function() {
     if (string == 'tomorrow')  return addDays(today, +1);
   }
 
+  function parseDayName(string, today, backwards) {
+    var days = map([1,2,3,4,5,6,7], function(x) {
+      return addDays(today, backwards ? -x : x);
+    });
+
+    days = inject(days, {}, function(a, x) {
+      a[DAY_NAMES[x.getDay()].toLowerCase()] = x;
+      a[ABBR_DAY_NAMES[x.getDay()].toLowerCase()] = x;
+      return a;
+    });
+
+    return days[string];
+  }
+
   function parseLastOrThisDay(string, today) {
     var tokens = string.split(DELIMITER);
 
     if (['last', 'next', 'this'].indexOf(tokens[0]) >= 0) {
-      var days = map([1,2,3,4,5,6,7], function(x) {
-        return addDays(today, tokens[0] == 'last' ? -x : x);
-      });
-
-      days = inject(days, {}, function(a, x) {
-        a[DAY_NAMES[x.getDay()].toLowerCase()] = x;
-        a[ABBR_DAY_NAMES[x.getDay()].toLowerCase()] = x;
-        return a;
-      });
-
-      return days[tokens[1]];
+      var backwards = tokens[0] == 'last';
+      return parseDayName(tokens[1], today, backwards);
     }
   }
 
@@ -124,6 +129,7 @@ var Kronic = (function() {
       string = trim(string + '').toLowerCase();
       return parseNearbyDays(   string, now) ||
              parseLastOrThisDay(string, now) ||
+             parseDayName(      string, now) ||
              parseExactDay(     string, now) ||
              parseIso8601Date(  string);
     },

--- a/lib/js/kronic.js
+++ b/lib/js/kronic.js
@@ -47,7 +47,7 @@ var Kronic = (function() {
   function parseLastOrThisDay(string, today) {
     var tokens = string.split(DELIMITER);
 
-    if (['last', 'this'].indexOf(tokens[0]) >= 0) {
+    if (['last', 'next', 'this'].indexOf(tokens[0]) >= 0) {
       var days = map([1,2,3,4,5,6,7], function(x) {
         return addDays(today, tokens[0] == 'last' ? -x : x);
       });

--- a/lib/js/kronic.js
+++ b/lib/js/kronic.js
@@ -9,7 +9,7 @@ var Kronic = (function() {
 
   var MONTH_NAMES = ["january", "jan", "february", "feb", "march", "mar", "april", "apr", "may", "may", "june", "jun", "july", "jul", "august", "aug", "september", "sep", "october", "oct", "november", "nov", "december", "dec"];
   var DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
-  var ABBR_DAY_NAMES = ["Sun", "Mon", "Tues", "Weds", "Thurs", "Fri", "Sat"];
+  var ABBR_DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   
   function trim(string) {
     return string.replace(/^\s+|\s+$/g, '');

--- a/lib/kronic.rb
+++ b/lib/kronic.rb
@@ -52,8 +52,8 @@ class Kronic
     NUMBER_WITH_ORDINAL = /^([0-9]+)(st|nd|rd|th)?$/
     ISO_8601_DATE       = /^([0-9]{4})-?(1[0-2]|0?[1-9])-?(3[0-1]|[1-2][0-9]|0?[1-9])$/
 
-    MONTH_NAMES = Date::MONTHNAMES.zip(Date::ABBR_MONTHNAMES).flatten.compact.map {|x| 
-                    x.downcase 
+    MONTH_NAMES = Date::MONTHNAMES.zip(Date::ABBR_MONTHNAMES).flatten.compact.map {|x|
+                    x.downcase
                   }
 
     # Ruby 1.8 does not provide a to_date method on Time. This methods works
@@ -95,6 +95,7 @@ class Kronic
           today + (tokens[0] == 'last' ? -x : x)
         }.inject({}) {|a, x|
           a.update(x.strftime("%A").downcase => x)
+          a.update(x.strftime("%a").downcase => x)
         }
 
         days[tokens[1]]

--- a/lib/kronic.rb
+++ b/lib/kronic.rb
@@ -90,7 +90,7 @@ class Kronic
     def parse_last_or_this_day(string, today)
       tokens = string.split(DELIMITER)
 
-      if %w(last this).include?(tokens[0])
+      if %w(last next this).include?(tokens[0])
         days = (1..7).map {|x|
           today + (tokens[0] == 'last' ? -x : x)
         }.inject({}) {|a, x|

--- a/lib/kronic.rb
+++ b/lib/kronic.rb
@@ -18,6 +18,7 @@ class Kronic
 
     parse_nearby_days(string, now) ||
       parse_last_or_this_day(string, now) ||
+      parse_day_name(string, now) ||
       parse_exact_date(string, now) ||
       parse_iso_8601_date(string)
   end
@@ -86,19 +87,25 @@ class Kronic
       return today + 1 if string == 'tomorrow'
     end
 
+    # Parse "Monday", "Mon"
+    def parse_day_name(string, today, backwards=false)
+      days = (1..7).map {|x|
+        today + (backwards ? -x : x)
+      }.inject({}) {|a, x|
+        a.update(x.strftime("%A").downcase => x)
+        a.update(x.strftime("%a").downcase => x)
+      }
+
+      days[string]
+    end
+
     # Parse "Last Monday", "This Monday"
     def parse_last_or_this_day(string, today)
       tokens = string.split(DELIMITER)
 
       if %w(last next this).include?(tokens[0])
-        days = (1..7).map {|x|
-          today + (tokens[0] == 'last' ? -x : x)
-        }.inject({}) {|a, x|
-          a.update(x.strftime("%A").downcase => x)
-          a.update(x.strftime("%a").downcase => x)
-        }
-
-        days[tokens[1]]
+        backwards = tokens[0] == 'last'
+        parse_day_name(tokens[1], today, backwards)
       end
     end
 

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -51,6 +51,7 @@ describe Kronic do
   it_should_parse('Tomorrow',           date(:today) + 1)
   it_should_parse('Last Monday',        date(:last_monday))
   it_should_parse('This Monday',        date(:next_monday))
+  it_should_parse('Next Monday',        date(:next_monday))
   it_should_parse('4 Sep',              date(:sep_4))
   it_should_parse('4  Sep',             date(:sep_4))
   it_should_parse('4 September',        date(:sep_4))

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -53,6 +53,7 @@ describe Kronic do
   it_should_parse('This Monday',        date(:next_monday))
   it_should_parse('Next Monday',        date(:next_monday))
   it_should_parse('Next Mon',           date(:next_monday))
+  it_should_parse('Mon',                date(:next_monday))
   it_should_parse('4 Sep',              date(:sep_4))
   it_should_parse('4  Sep',             date(:sep_4))
   it_should_parse('4 September',        date(:sep_4))

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -52,6 +52,7 @@ describe Kronic do
   it_should_parse('Last Monday',        date(:last_monday))
   it_should_parse('This Monday',        date(:next_monday))
   it_should_parse('Next Monday',        date(:next_monday))
+  it_should_parse('Next Mon',           date(:next_monday))
   it_should_parse('4 Sep',              date(:sep_4))
   it_should_parse('4  Sep',             date(:sep_4))
   it_should_parse('4 September',        date(:sep_4))


### PR DESCRIPTION
Hi, I ran into a few cases which users were expecting to be supported:
- "next monday", the same as "this monday"
- Abbreviated day names, so "tues" will work. Again, the same as "this tues"
- Exact day names, so you can be super lazy and just type "fri" for "this friday"

All specs pass, I had to modify the Gemfile to get it to work on 1.8.x as EUBY_ENGINE isn't defined there.

Hope that's of some use!

Thanks.
