### PR TITLE
Fixed failing JS tests and added support for format "21/04/2011"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
     rspec-mocks (2.0.1)
       rspec-core (~> 2.0.1)
       rspec-expectations (~> 2.0.1)
+    therubyracer (0.8.2.pre2)
     timecop (0.3.5)
     tzinfo (0.3.24)
 
@@ -33,5 +34,6 @@ DEPENDENCIES
   kronic!
   rake
   rspec (~> 2.0.1)
+  therubyracer (>= 0.8.0.pre2)
   timecop
   tzinfo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.3)
+    activesupport (3.0.7)
     diff-lcs (1.1.2)
     i18n (0.5.0)
     rake (0.8.7)
@@ -20,9 +20,9 @@ GEM
     rspec-mocks (2.0.1)
       rspec-core (~> 2.0.1)
       rspec-expectations (~> 2.0.1)
-    therubyracer (0.8.2.pre2)
+    therubyracer (0.9.0beta3)
     timecop (0.3.5)
-    tzinfo (0.3.24)
+    tzinfo (0.3.27)
 
 PLATFORMS
   ruby

--- a/lib/js/kronic.js
+++ b/lib/js/kronic.js
@@ -2,7 +2,7 @@
  * See kronic.rb for explanatory remarks.
  */
 var Kronic = (function() { 
-  var DELIMITER           = /[,\s]+/;
+  var DELIMITER           = /[,\/\s]+/;
   var NUMBER              = /^[0-9]+$/;
   var NUMBER_WITH_ORDINAL = /^([0-9]+)(st|nd|rd|th)?$/;
   var ISO_8601_DATE       = /^([0-9]{4})-?(1[0-2]|0?[1-9])-?(3[0-1]|[1-2][0-9]|0?[1-9])$/;
@@ -80,10 +80,10 @@ var Kronic = (function() {
 
   function parseExactDateParts(rawDay, rawMonth, rawYear, today) {
     var day = rawDay * 1;
-    var month = monthFromName(rawMonth);
+    var month = rawMonth.match(NUMBER) ? rawMonth - 1 : monthFromName(rawMonth);
     var year;
-
-    if (rawYear)
+    
+	if (rawYear)
       year = rawYear.match(NUMBER) ? rawYear * 1 : null;
     else
       year = today.getYear() + 1900;

--- a/lib/kronic.rb
+++ b/lib/kronic.rb
@@ -89,7 +89,6 @@ class Kronic
     # Parse "Last Monday", "This Monday"
     def parse_last_or_this_day(string, today)
       tokens = string.split(DELIMITER)
-      $stderr.puts tokens.inspect
 
       if %w(last this).include?(tokens[0])
         days = (1..7).map {|x|

--- a/lib/kronic.rb
+++ b/lib/kronic.rb
@@ -47,7 +47,7 @@ class Kronic
   class << self
     private
 
-    DELIMITER           = /[,\s]+/
+    DELIMITER           = /[,\/\s]+/
     NUMBER              = /^[0-9]+$/
     NUMBER_WITH_ORDINAL = /^([0-9]+)(st|nd|rd|th)?$/
     ISO_8601_DATE       = /^([0-9]{4})-?(1[0-2]|0?[1-9])-?(3[0-1]|[1-2][0-9]|0?[1-9])$/
@@ -89,6 +89,7 @@ class Kronic
     # Parse "Last Monday", "This Monday"
     def parse_last_or_this_day(string, today)
       tokens = string.split(DELIMITER)
+      $stderr.puts tokens.inspect
 
       if %w(last this).include?(tokens[0])
         days = (1..7).map {|x|
@@ -117,7 +118,7 @@ class Kronic
     # Parses day, month and year parts
     def parse_exact_date_parts(raw_day, raw_month, raw_year, today)
       day   = raw_day.to_i
-      month = month_from_name(raw_month)
+      month = month_from_name(raw_month) || raw_month.to_i
       year = if raw_year
         raw_year =~ NUMBER ? raw_year.to_i : nil
       else

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -69,8 +69,8 @@ describe Kronic do
   it_should_parse('1 Jan 2010',         Date.new(2010, 1, 1))
   it_should_parse('31 Dec 2010',        Date.new(2010, 12, 31))
   
-  it_should_parse('04/09/2008',         Date.new(2008, 9, 4))
-  it_should_parse('4/9/2008',           Date.new(2008, 9, 4))
+  it_should_parse('21/04/2011',         Date.new(2011, 4, 21))
+  it_should_parse('21/04/2011',         Date.new(2011, 4, 21))
 
   it_should_parse('0 Jan 2010',         nil)
   it_should_parse('32 Dec 2010',        nil)

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -69,7 +69,7 @@ describe Kronic do
   it_should_parse('1 Jan 2010',         Date.new(2010, 1, 1))
   it_should_parse('31 Dec 2010',        Date.new(2010, 12, 31))
   
-  it_should_parse('04/09/2008',           Date.new(2008, 9, 4))
+  it_should_parse('04/09/2008',         Date.new(2008, 9, 4))
   it_should_parse('4/9/2008',           Date.new(2008, 9, 4))
 
   it_should_parse('0 Jan 2010',         nil)

--- a/spec/kronic_spec.rb
+++ b/spec/kronic_spec.rb
@@ -68,6 +68,9 @@ describe Kronic do
   it_should_parse('2008-9-4',           Date.new(2008, 9, 4))
   it_should_parse('1 Jan 2010',         Date.new(2010, 1, 1))
   it_should_parse('31 Dec 2010',        Date.new(2010, 12, 31))
+  
+  it_should_parse('04/09/2008',           Date.new(2008, 9, 4))
+  it_should_parse('4/9/2008',           Date.new(2008, 9, 4))
 
   it_should_parse('0 Jan 2010',         nil)
   it_should_parse('32 Dec 2010',        nil)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,5 +66,6 @@ module KronicMatchers
 end
 
 def js_supported?
+  return false
   $js_loaded
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ module KronicMatchers
 
     if js_supported?
       it "should parse '#{string}' (JS)" do
-        x = @js.evaluate("Kronic").parse(string)
+        x = @js.eval("Kronic").parse(string)
 
         if x.is_a?(Time)
           x = x.to_date
@@ -59,13 +59,12 @@ module KronicMatchers
 
     if js_supported?
       it "should format '#{string}' (JS)" do
-        @js.evaluate("Kronic").format(date.to_time).should == string
+        @js.eval("Kronic").format(date.to_time).should == string
       end
     end
   end
 end
 
 def js_supported?
-  return false
   $js_loaded
 end


### PR DESCRIPTION
JS tests currently fail as evaluation is depreciated for eval. This is now fixed.

I also added support for 21/04/2011 by allowing month numbers and / as a delimiter.

All tests pass and there are new tests for the new date format.
